### PR TITLE
fix main.c for kernel 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ sudo depmod
 Tun and done!
 
 
-The above sources were taken from kernel version 4.12
+The above sources were taken from kernel version 4.12 and slightly modified for newer kernel
 
-They appear to work fine on 4.17.2 as well
+They appear to work fine on 5.0.0 as well
 
 And here is the faulty commit:
 

--- a/main.c
+++ b/main.c
@@ -660,10 +660,10 @@ static int alx_alloc_rings(struct alx_priv *alx)
 			    alx->num_txq +
 			    sizeof(struct alx_rrd) * alx->rx_ringsz +
 			    sizeof(struct alx_rfd) * alx->rx_ringsz;
-	alx->descmem.virt = dma_zalloc_coherent(&alx->hw.pdev->dev,
-						alx->descmem.size,
-						&alx->descmem.dma,
-						GFP_KERNEL);
+	alx->descmem.virt = dma_alloc_coherent(&alx->hw.pdev->dev,
+					       alx->descmem.size,
+					       &alx->descmem.dma,
+					       GFP_KERNEL);
 	if (!alx->descmem.virt)
 		return -ENOMEM;
 


### PR DESCRIPTION
Build fails on kernel version >=5.
`dma_zalloc_coherent()` is removed from kernel. `dma_alloc_coherent()` already zeroes out memory for us so we can use it instead.